### PR TITLE
Update decorators.py

### DIFF
--- a/src/flask_cognito_lib/decorators.py
+++ b/src/flask_cognito_lib/decorators.py
@@ -51,7 +51,7 @@ def cognito_login(fn):
             # Add suport for custom state values which are appended to a secure
             # random value for additional CRSF protection
             state = secure_random()
-            custom_state = session.get("state", default=None)
+            custom_state = session.get("state")
             if custom_state:
                 state += f"__{custom_state}"
 


### PR DESCRIPTION
Thank you for a great repository!

From the official python docs: 

get(key[, default])
Return the value for key if key is in the dictionary, else default. If default is not given, it defaults to None, so that this method never raises a KeyError.

Specifying a keyword argument causes an error, at least on my machine. 

Ubuntu 20.04.5
Python 3.9.16

https://docs.python.org/3.10/library/stdtypes.html?highlight=dict%20get#dict.get