### PR TITLE
Support not using app secret

### DIFF
--- a/src/flask_cognito_lib/config.py
+++ b/src/flask_cognito_lib/config.py
@@ -67,7 +67,7 @@ class Config:
     @property
     def user_pool_client_secret(self) -> str:
         """Return the Cognito user pool client secret"""
-        return get("AWS_COGNITO_USER_POOL_CLIENT_SECRET", required=True)
+        return get("AWS_COGNITO_USER_POOL_CLIENT_SECRET", required=False)
 
     @property
     def redirect_url(self) -> str:

--- a/src/flask_cognito_lib/services/cognito_svc.py
+++ b/src/flask_cognito_lib/services/cognito_svc.py
@@ -96,11 +96,19 @@ class CognitoService:
             "code_verifier": code_verifier,
         }
 
+        # The Authorization header must not be present when using a
+        # Public Client, we assume this when the secret is blank.
+        # (Blank secrets are not supported on Confidential Clients)
+        if self.cfg.user_pool_client_secret:
+            auth = (self.cfg.user_pool_client_id, self.cfg.user_pool_client_secret)
+        else:
+            auth = None
+
         try:
             response = requests.post(
                 url=self.cfg.token_endpoint,
                 data=data,
-                auth=(self.cfg.user_pool_client_id, self.cfg.user_pool_client_secret),
+                auth=auth,
             )
             response_json = response.json()
 

--- a/tests/test_cognito_svc.py
+++ b/tests/test_cognito_svc.py
@@ -52,6 +52,7 @@ def test_exchange_code_for_token(cfg, mocker):
     token = cognito.exchange_code_for_token(code="test_code", code_verifier="asdf")
     assert token.access_token == "test_access_token"
 
+
 def test_exchange_code_for_token_with_public_client(app, cfg, mocker):
     mocker.patch(
         "requests.post",

--- a/tests/test_cognito_svc.py
+++ b/tests/test_cognito_svc.py
@@ -52,6 +52,18 @@ def test_exchange_code_for_token(cfg, mocker):
     token = cognito.exchange_code_for_token(code="test_code", code_verifier="asdf")
     assert token.access_token == "test_access_token"
 
+def test_exchange_code_for_token_with_public_client(app, cfg, mocker):
+    mocker.patch(
+        "requests.post",
+        return_value=mocker.Mock(json=lambda: {"access_token": "test_access_token"}),
+    )
+
+    app.config.pop("AWS_COGNITO_USER_POOL_CLIENT_SECRET")
+
+    cognito = CognitoService(cfg)
+    token = cognito.exchange_code_for_token(code="test_code", code_verifier="asdf")
+    assert token.access_token == "test_access_token"
+
 
 def test_exchange_code_for_token_error(cfg, mocker):
     mocker.patch(


### PR DESCRIPTION
Hi! Thanks for this library, it's ultra useful! I've hit a snag with one of our apps though:

When creating a Public Cognito app, you can opt not to use a Client Secret.

The Authorization header is an optional way to pass the App Client ID and App Client Secret, but if the Secret isn't enabled for the given app client, then the Authorization header stops being optional, and becomes _forbidden_... 

I've done some testing and found that there's no valid Authorization header for this use case, and you have to just avoid setting it at all, otherwise Cognito returns
```
Code: 400
Body: { "error": "invalid_client" }
```

Some other people have found this too and discussed here: https://stackoverflow.com/questions/54578397/token-endpoint-returns-invalid-client-without-client-secret

The intention of this pull request is to not set the Authorization header if `user_pool_client_secret` is `''` or `None`

Please let me know if this is a valid approach,
Thanks!