### PR TITLE
Fix deprecation warning: _app_ctx_stack -> g

### DIFF
--- a/src/flask_cognito_lib/plugin.py
+++ b/src/flask_cognito_lib/plugin.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Dict, Optional
 
 from flask import Flask
-from flask import _app_ctx_stack as ctx_stack
+from flask import g
 
 from flask_cognito_lib.config import Config
 from flask_cognito_lib.exceptions import CognitoError
@@ -51,12 +51,10 @@ class CognitoAuth:
         TokenService
             An instance of TokenService
         """
-        ctx = ctx_stack.top
-        if ctx is not None:
-            if not hasattr(ctx, self.cfg.CONTEXT_KEY_TOKEN_SERVICE):
-                token_service = self.token_service_factory(cfg=self.cfg)
-                setattr(ctx, self.cfg.CONTEXT_KEY_TOKEN_SERVICE, token_service)
-            return getattr(ctx, self.cfg.CONTEXT_KEY_TOKEN_SERVICE)
+        if not hasattr(g, self.cfg.CONTEXT_KEY_TOKEN_SERVICE):
+            token_service = self.token_service_factory(cfg=self.cfg)
+            setattr(g, self.cfg.CONTEXT_KEY_TOKEN_SERVICE, token_service)
+        return getattr(g, self.cfg.CONTEXT_KEY_TOKEN_SERVICE)
 
     @property
     def cognito_service(self) -> CognitoService:
@@ -67,12 +65,10 @@ class CognitoAuth:
         CognitoService
             An instance of CognitoService
         """
-        ctx = ctx_stack.top
-        if ctx is not None:
-            if not hasattr(ctx, self.cfg.CONTEXT_KEY_COGNITO_SERVICE):
-                cognito_service = self.cognito_service_factory(cfg=self.cfg)
-                setattr(ctx, self.cfg.CONTEXT_KEY_COGNITO_SERVICE, cognito_service)
-            return getattr(ctx, self.cfg.CONTEXT_KEY_COGNITO_SERVICE)
+        if not hasattr(g, self.cfg.CONTEXT_KEY_COGNITO_SERVICE):
+            cognito_service = self.cognito_service_factory(cfg=self.cfg)
+            setattr(g, self.cfg.CONTEXT_KEY_COGNITO_SERVICE, cognito_service)
+        return getattr(g, self.cfg.CONTEXT_KEY_COGNITO_SERVICE)
 
     def get_tokens(
         self,

--- a/src/flask_cognito_lib/plugin.py
+++ b/src/flask_cognito_lib/plugin.py
@@ -1,7 +1,6 @@
 from typing import Any, Callable, Dict, Optional
 
-from flask import Flask
-from flask import g
+from flask import Flask, g
 
 from flask_cognito_lib.config import Config
 from flask_cognito_lib.exceptions import CognitoError


### PR DESCRIPTION
There are Flask deprecation warnings, this PR aims to update to the current approach recommended by Flask
```
======================================= warnings summary ========================================tests/test_decorators.py::test_cognito_login
tests/test_decorators.py::test_cognito_custom_state
tests/test_decorators.py::test_cognito_custom_scopes
tests/test_plugin.py::test_plugin_get_tokens
  /home/jak/code/flask-cognito-lib/src/flask_cognito_lib/plugin.py:70: DeprecationWarning: '_app_ctx_stack' is deprecated and will be removed in Flask 2.4. Use 'g' to store data, or 'app_ctx' to access the current context.
    ctx = ctx_stack.top

tests/test_decorators.py: 10 tests with warnings
  /home/jak/code/flask-cognito-lib/src/flask_cognito_lib/plugin.py:54: DeprecationWarning: '_app_ctx_stack' is deprecated and will be removed in Flask 2.4. Use 'g' to store data, or 'app_ctx' to access the current context.
    ctx = ctx_stack.top
```

I think I've used the right approach here, slightly hesitant to have removed the `if ctx is not None:` check, and wondering if it should be replaced by something like
```
with app.app_context():
```

Thanks,
Jak
