### PR TITLE
adding cookie domain option per discussion #25

### DIFF
--- a/src/flask_cognito_lib/config.py
+++ b/src/flask_cognito_lib/config.py
@@ -149,3 +149,8 @@ class Config:
     def revoke_endpoint(self) -> str:
         """Return the Cognito REVOKE endpoint URL"""
         return f"{self.domain}/oauth2/revoke"
+
+    @property
+    def cookie_domain(self) -> str:
+        """Domain name of the cookie"""
+        return get("AWS_COGNITO_COOKIE_DOMAIN", required=False, default=None)

--- a/src/flask_cognito_lib/decorators.py
+++ b/src/flask_cognito_lib/decorators.py
@@ -125,6 +125,7 @@ def cognito_login_callback(fn):
                 max_age=cfg.max_cookie_age_seconds,
                 httponly=True,
                 secure=True,
+                domain=cfg.cookie_domain
             )
 
         return resp
@@ -140,7 +141,7 @@ def cognito_logout(fn):
         with app.app_context():
             # logout at cognito and remove the cookies
             resp = redirect(cfg.logout_endpoint)
-            resp.delete_cookie(key=cfg.COOKIE_NAME)
+            resp.delete_cookie(key=cfg.COOKIE_NAME, domain=cfg.cookie_domain)
 
         # Cognito will redirect to the sign-out URL (if set) or else use
         # the callback URL


### PR DESCRIPTION
Adding cookie domain option per discussion #25

Looks like you have Github hooks setup for test but I'm not sure if they automate adding / removing cookies from domains. Not sure how that could be tested without some sort of headless browser. I tested functionality locally with ngrok and all seems to checkout but domains and cookies can be tricky per this post https://stackoverflow.com/questions/18492576/share-cookies-between-subdomain-and-domain

