### PR TITLE
flask 3 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-Flask = "~=2.0"
+Flask = ">=2.0,<3.1"
 requests = "~=2.0"
-PyJWT = { extras = ["crypto"], version = ">=2.4,<3.0" }
+PyJWT = { extras = ["crypto"], version = ">=2.4,<=4.*" }
 urllib3 = "<=2.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ packages = [
 python = "^3.8"
 Flask = ">=2.0,<3.1"
 requests = "~=2.0"
-PyJWT = { extras = ["crypto"], version = ">=2.4,<=4.*" }
+PyJWT = { extras = ["crypto"], version = ">=2.4,<3.0" }
 urllib3 = "<=2.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-Flask = ">=2.0,<3.1"
+Flask = ">=2.0"
 requests = "~=2.0"
 PyJWT = { extras = ["crypto"], version = ">=2.4,<3.0" }
 urllib3 = "<=2.0"

--- a/src/flask_cognito_lib/config.py
+++ b/src/flask_cognito_lib/config.py
@@ -149,3 +149,8 @@ class Config:
     def revoke_endpoint(self) -> str:
         """Return the Cognito REVOKE endpoint URL"""
         return f"{self.domain}/oauth2/revoke"
+
+    @property
+    def cookie_domain(self) -> str:
+        """Domain name of the cookie"""
+        return get("AWS_COGNITO_COOKIE_DOMAIN", required=False, default=None)

--- a/src/flask_cognito_lib/config.py
+++ b/src/flask_cognito_lib/config.py
@@ -157,5 +157,5 @@ class Config:
     
     @property
     def cookie_samesite(self) -> str:
-        """Samesite property of cookie"""
+        """Samesite property of cookie. 'Lax', 'Strict', or None"""
         return get("AWS_COGNITO_COOKIE_SAMESITE", required=False, default=None)

--- a/src/flask_cognito_lib/config.py
+++ b/src/flask_cognito_lib/config.py
@@ -154,3 +154,8 @@ class Config:
     def cookie_domain(self) -> str:
         """Domain name of the cookie"""
         return get("AWS_COGNITO_COOKIE_DOMAIN", required=False, default=None)
+    
+    @property
+    def cookie_samesite(self) -> str:
+        """Samesite property of cookie"""
+        return get("AWS_COGNITO_COOKIE_SAMESITE", required=False, default=None)

--- a/src/flask_cognito_lib/decorators.py
+++ b/src/flask_cognito_lib/decorators.py
@@ -125,7 +125,8 @@ def cognito_login_callback(fn):
                 max_age=cfg.max_cookie_age_seconds,
                 httponly=True,
                 secure=True,
-                domain=cfg.cookie_domain
+                domain=cfg.cookie_domain,
+                samesite=cfg.cookie_samesite
             )
 
         return resp

--- a/src/flask_cognito_lib/decorators.py
+++ b/src/flask_cognito_lib/decorators.py
@@ -125,6 +125,7 @@ def cognito_login_callback(fn):
                 max_age=cfg.max_cookie_age_seconds,
                 httponly=True,
                 secure=True,
+                domain=cfg.cookie_domain
             )
 
         return resp
@@ -140,7 +141,7 @@ def cognito_logout(fn):
         with app.app_context():
             # logout at cognito and remove the cookies
             resp = redirect(cfg.logout_endpoint)
-            resp.delete_cookie(key=cfg.COOKIE_NAME)
+            resp.delete_cookie(key=cfg.COOKIE_NAME, domain=cfg.cookie_domain)
 
         # Cognito will redirect to the sign-out URL (if set) or else use
         # the callback URL


### PR DESCRIPTION
This PR resolves #26, i.e. support for Flask 3 but also has support for setting cookie options

- cookie_domain
- cookie_samesite

@mblackgeo let me know if you'd like to merge these changes in. Please note that I left support for Flask to have no upper version restriction. `Flask = ">=2.0"` I have all my changes in this one PR as I thought it might be easier. You can delete them if you don't want them and I can just use my repo but thought I'd offer my changes.
