### PR TITLE
feat: decorator use config from app context

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,40 @@ if __name__ == "__main__":
     app.run()
 ```
 
+## Config class override
+
+There might be some cases where you want to override the default `Config` class to add custom logic. For example, to generate the `redirect_url` and `logout_redirect` dynamically using `url_for`, you can override the `Config` class as follows:
+
+```python
+from flask import url_for
+from flask_cognito_lib.config import Config
+
+class ConfigOverride(Config):
+    """
+    ConfigOverride class to generate URLs dynamically using `url_for`
+    """
+    @property
+    def redirect_url(self) -> str:
+        """Return the Redirect URL (post-login)"""
+        return url_for(endpoint='auth.cognito', _external=True)
+
+    @property
+    def logout_redirect(self) -> str:
+        """Return the Redirect URL (post-logout)"""
+        return url_for(endpoint='auth.cognito_post_logout', _external=True)
+```
+
+Then, pass the object of `ConfigOverride` class when initializing the `CognitoAuth` plugin as follows:
+
+```python
+CognitoAuth(app, cfg=ConfigOverride())
+```
+
+Or if you are using lazy initialization:
+
+```python
+CognitoAuth().init_app(app, cfg=ConfigOverride())
+```
 
 ## Development
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,6 +157,41 @@ if __name__ == "__main__":
     app.run()
 ```
 
+## Config class override
+
+There might be some cases where you want to override the default `Config` class to add custom logic. For example, to generate the `redirect_url` and `logout_redirect` dynamically using `url_for`, you can override the `Config` class as follows:
+
+```python
+from flask import url_for
+from flask_cognito_lib.config import Config
+
+class ConfigOverride(Config):
+    """
+    ConfigOverride class to generate URLs dynamically using `url_for`
+    """
+    @property
+    def redirect_url(self) -> str:
+        """Return the Redirect URL (post-login)"""
+        return url_for(endpoint='auth.cognito', _external=True)
+
+    @property
+    def logout_redirect(self) -> str:
+        """Return the Redirect URL (post-logout)"""
+        return url_for(endpoint='auth.cognito_post_logout', _external=True)
+```
+
+Then, pass the object of `ConfigOverride` class when initializing the `CognitoAuth` plugin as follows:
+
+```python
+CognitoAuth(app, cfg=ConfigOverride())
+```
+
+Or if you are using lazy initialization:
+
+```python
+CognitoAuth().init_app(app, cfg=ConfigOverride())
+```
+
 
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change. Please make sure to update tests as appropriate and ensure 100% test coverage.

--- a/src/flask_cognito_lib/plugin.py
+++ b/src/flask_cognito_lib/plugin.py
@@ -16,6 +16,7 @@ class CognitoAuth:
         app: Optional[Flask] = None,
         _token_service_factory: Callable = token_service_factory,
         _cognito_service_factory: Callable = cognito_service_factory,
+        cfg: Optional[Config] = None,
     ):
         """Instantiate the CognitoAuth manager
 
@@ -24,21 +25,28 @@ class CognitoAuth:
         app : Optional[Flask], optional
             An optional instance of a Flask application. If doing lazy init
             use the `init_app` method instead
+        cfg : Optional[Config], optional
+            Configuration object to use. If not provided, a default Config is used.
         """
         self.token_service_factory = _token_service_factory
         self.cognito_service_factory = _cognito_service_factory
         if app is not None:
-            self.init_app(app)
+            self.init_app(app=app, cfg=cfg)
 
-    def init_app(self, app: Flask):
+    def init_app(self, app: Flask, cfg: Optional[Config] = None):
         """Register the extension with a Flask application
 
         Parameters
         ----------
         app : Flask
             Flask application
+        cfg : Optional[Config], optional
+            Configuration object to use. If not provided, a default Config is used.
         """
-        self.cfg = Config()
+        if cfg:
+            self.cfg = cfg
+        else:
+            self.cfg = Config()
         app.extensions[self.cfg.APP_EXTENSION_KEY] = self
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,6 +135,16 @@ def cfg():
     return Config()
 
 
+@pytest.fixture
+def cfg_override():
+    class ConfigOverride(Config):
+        @property
+        def logout_redirect(self) -> str:
+            return "http://localhost:8000/postlogout"
+
+    return ConfigOverride()
+
+
 @pytest.fixture(autouse=True)
 def jwk_patch(mocker, jwks):
     # Return the keys from the user pool without hitting the real endpoint
@@ -226,4 +236,11 @@ def client_with_cookie_refresh_encrypted(
     cl.application.config["AWS_COGNITO_REFRESH_COOKIE_ENCRYPTED"] = True
     cl.set_cookie(key=cfg.COOKIE_NAME, value=access_token)
     cl.set_cookie(key=cfg.COOKIE_NAME_REFRESH, value=refresh_token_encrypted)
+    yield cl
+
+
+@pytest.fixture
+def client_with_config_override(app, cfg_override):
+    cl = app.test_client()
+    cl.application.extensions[cfg_override.APP_EXTENSION_KEY].cfg = cfg_override
     yield cl

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -298,7 +298,8 @@ def test_cognito_logout(client, cfg):
 
 
 def test_cognito_logout_override(client_with_config_override, cfg_override):
-    # should 302 redirect to cognito
+    # should 302 redirect to cognito, logout endpoint should be the overridden
+    # from the custom Config object
     response = client_with_config_override.get("/logout")
     assert response.status_code == 302
     assert response.headers["location"].startswith(cfg_override.logout_endpoint)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -297,6 +297,13 @@ def test_cognito_logout(client, cfg):
     assert response.headers["location"].startswith(cfg.logout_endpoint)
 
 
+def test_cognito_logout_override(client_with_config_override, cfg_override):
+    # should 302 redirect to cognito
+    response = client_with_config_override.get("/logout")
+    assert response.status_code == 302
+    assert response.headers["location"].startswith(cfg_override.logout_endpoint)
+
+
 def test_cognito_logout_with_refresh_token(client_with_cookie_refresh, cfg, mocker):
     # Mock the refresh token revocation
     mocker.patch(

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -11,10 +11,28 @@ def test_plugin_init(cfg):
     assert cfg.APP_EXTENSION_KEY in app.extensions
 
 
+def test_plugin_init_with_config_override(cfg_override):
+    app = Flask(__name__)
+    CognitoAuth(app, cfg=cfg_override)
+    assert (
+        app.extensions[cfg_override.APP_EXTENSION_KEY].cfg.logout_redirect
+        == cfg_override.logout_redirect
+    )
+
+
 def test_plugin_lazy_init(cfg):
     app = Flask(__name__)
     CognitoAuth().init_app(app)
     assert cfg.APP_EXTENSION_KEY in app.extensions
+
+
+def test_plugin_lazy_init_with_config_override(cfg_override):
+    app = Flask(__name__)
+    CognitoAuth().init_app(app, cfg=cfg_override)
+    assert (
+        app.extensions[cfg_override.APP_EXTENSION_KEY].cfg.logout_redirect
+        == cfg_override.logout_redirect
+    )
 
 
 def test_plugin_get_tokens_parameters_state(app, cfg):


### PR DESCRIPTION
# Description

First commit https://github.com/mblackgeo/flask-cognito-lib/pull/43/commits/e54226b4c841b4a3a145b05320f07d595155b214 demonstrates the issue where custom `Config` class is provided but decorator does not respect the override.

Second commit https://github.com/mblackgeo/flask-cognito-lib/pull/43/commits/974c11ce08cb927bf13b15f595f53824956ae2b3 resolves the issue by getting the config from the application context.

Resolves:

- #42 

Depends on:

- #41 
- #39


ToDo:

- [x]  Test coverage