### PR TITLE
Add descriptions to exceptions

### DIFF
--- a/src/flask_cognito_lib/exceptions.py
+++ b/src/flask_cognito_lib/exceptions.py
@@ -19,7 +19,9 @@ class CognitoError(FlaskCognitoError):
 
 class AuthorisationRequiredError(HTTPException):
     code = 403
+    description = "Authorization is required to access this resource."
 
 
 class CognitoGroupRequiredError(HTTPException):
     code = 403
+    description = "Cognito group membership is required to access this resource."


### PR DESCRIPTION
* The repo has as dependency Flask = ">=2.0,<4.0"
* The repo also uses Werkzeug (for example in the edited file)
* Flask>=2.0 requires Werkzeug>=2.0
* When accesing an protected route the following error appears
![image](https://github.com/user-attachments/assets/e5573a7e-254b-43c1-8ce6-ffe32a418610)

This is because HTTPException.description can no longer be None in werkzeug 2.x ([commit](https://github.com/pallets/werkzeug/commit/5fd13860d7f649fbe592601b1dea728050daffa5#diff-b9d6906a0da8b5a9877b17ac5ea491161a660ce7e513921738d3e284bd9e9c96R453))

In this PR I only add a very simple description to both exceptions to avoid the errors
