### PR TITLE
Verify token consistency; Clear session upon logout

### DIFF
--- a/src/flask_cognito_lib/decorators.py
+++ b/src/flask_cognito_lib/decorators.py
@@ -282,6 +282,8 @@ def cognito_logout(fn):
                     domain=cognito_auth.cfg.cookie_domain,
                 )
 
+            remove_from_session(("claims", "user_info"))
+
         # Cognito will redirect to the sign-out URL (if set) or else use
         # the callback URL
         return resp
@@ -316,6 +318,11 @@ def auth_required(groups: Optional[Iterable[str]] = None, any_group: bool = Fals
                         token=access_token,
                         leeway=cognito_auth.cfg.cognito_expiration_leeway,
                     )
+
+                    # Check for token consistency
+                    if claims["sub"] != session["claims"]["sub"]:
+                        raise TokenVerifyError
+
                     # Check for required group membership
                     if groups:
                         if not check_group_membership(claims, groups, any_group):


### PR DESCRIPTION
Say we have this situation:
* You log into a public computer, deal with some business and log out.
* Your evil colleague takes over this public computer, and is able to retrieve **your session cookie** of the same URL domain left in the browser (since the session is not cleared upon logout)
* Your evil colleague then logs into the same system, replace his/her session cookie with **your session cookie**
* BOOM! You evil colleague successfully impersonate your account, because his/her access token is valid, and your session cookie is valid.

Based on my test, this is entirely feasible. Does it make sense to you? Discussions or objections are very welcome 😄