### PR TITLE
Fix typo: exhange_refresh_token to exchange_refresh_token

### DIFF
--- a/src/flask_cognito_lib/plugin.py
+++ b/src/flask_cognito_lib/plugin.py
@@ -149,7 +149,7 @@ class CognitoAuth:
             If the request to the TOKEN endpoint fails
             If the TOKEN endpoint returns an error code
         """
-        return self.cognito_service.exhange_refresh_token(
+        return self.cognito_service.exchange_refresh_token(
             refresh_token=refresh_token,
         )
 

--- a/src/flask_cognito_lib/services/cognito_svc.py
+++ b/src/flask_cognito_lib/services/cognito_svc.py
@@ -99,7 +99,7 @@ class CognitoService:
 
         return self._request_token(data)
 
-    def exhange_refresh_token(
+    def exchange_refresh_token(
         self,
         refresh_token: str,
     ) -> CognitoTokenResponse:
@@ -129,6 +129,7 @@ class CognitoService:
         }
 
         return self._request_token(data)
+    exhange_refresh_token = exchange_refresh_token
 
     def revoke_refresh_token(
         self,

--- a/tests/test_cognito_svc.py
+++ b/tests/test_cognito_svc.py
@@ -141,7 +141,7 @@ def test_refresh_token(cfg, mocker):
     )
 
     cognito = CognitoService(cfg)
-    token = cognito.exhange_refresh_token(refresh_token="test_refresh_token")
+    token = cognito.exchange_refresh_token(refresh_token="test_refresh_token")
 
     assert token.access_token == "new_test_access_token"
     assert token.refresh_token == "new_test_refresh_token"


### PR DESCRIPTION
Rename exhange_refresh_token to exchange_refresh_token while keeping the old method name for backward-compatibility